### PR TITLE
feat: verify portal token

### DIFF
--- a/ncu_hsys/constants.py
+++ b/ncu_hsys/constants.py
@@ -22,6 +22,7 @@ class LOGIN_PAGE_XPATH(enumerate):
     LOGIN_NAME = "//*[@id=\"inputAccount\"]/@value"
     USERNAME = "/html/body/section/div/div/div[1]/div/div/form/fieldset/div[1]/input[2]/@value"
     REMEMBER_AS = "/html/body/section/div/div/div[1]/div/div/form/fieldset/div[1]/input[3]/@value"
+    REMAING_DAY_MSG = "/html/body/section/div/div/div[1]/div/div/form/fieldset/div[1]/ul/li[1]/text()"
 
 
 class SIGNIN_PAGE_XPATH(enumerate):
@@ -29,5 +30,6 @@ class SIGNIN_PAGE_XPATH(enumerate):
     CORE_SCRIPT = "/html/body/div[4]/div/script/text()"
 
 
+ACCEPT_LANGUAGE = "zh-TW,zh;q=0.8,en-US;q=0.6,en;q=0.4"
 BROWSER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
 PORTAL_COOKIE_DOMAIN = "portal.ncu.edu.tw"

--- a/ncu_hsys/sign_bot.py
+++ b/ncu_hsys/sign_bot.py
@@ -4,9 +4,10 @@ import logging
 import requests
 from lxml import etree
 from dotenv import load_dotenv
-from notification.notifier import Notifier
+
+from ncu_hsys.utils.browser import init_browser
 from .constants import NCU_PORTAL_URL, HUMAN_SYS_URL, MENU_SELECT, \
-    LOGIN_PAGE_XPATH, SIGNIN_PAGE_XPATH, BROWSER_USER_AGENT, PORTAL_COOKIE_DOMAIN
+    LOGIN_PAGE_XPATH, SIGNIN_PAGE_XPATH
 
 
 def init_logger():
@@ -49,17 +50,6 @@ def check_type(portal_token: str, parttime_usually_id: int) -> None:
     # 檢查 parttime_usually_id 是否為 int
     if (not isinstance(parttime_usually_id, int)):
         raise TypeError("parttime_usually_id 並非整數")
-
-
-def init_browser(portal_toekn: str) -> requests.Session:
-    # 初始化 Session
-    browser = requests.Session()
-    # 將 PORTAL_TOKEN 設定為 cookie: portal
-    browser.cookies.set("portal", portal_toekn, domain=PORTAL_COOKIE_DOMAIN)
-    # 設定模擬瀏覽器的 User-Agent Header
-    browser.headers.update({"User-Agent": BROWSER_USER_AGENT})
-
-    return browser
 
 
 def login_ncu_portal(browser: requests.Session) -> None:
@@ -140,6 +130,8 @@ def gen_signin_payload(browser: requests.Session, parttime_usually_id: int) -> d
 
     # 解析頁面
     html = etree.HTML(res.text)
+
+    print(res.text)
 
     # 從頁面提取目前簽到的紀錄 ID
     # 若為簽到狀態為空值，若為簽退狀態則為上次簽到的紀錄 ID

--- a/ncu_hsys/utils/browser.py
+++ b/ncu_hsys/utils/browser.py
@@ -1,0 +1,14 @@
+import requests
+from ..constants import ACCEPT_LANGUAGE, BROWSER_USER_AGENT, PORTAL_COOKIE_DOMAIN
+
+
+def init_browser(portal_toekn: str) -> requests.Session:
+    # 初始化 Session
+    browser = requests.Session()
+    # 將 PORTAL_TOKEN 設定為 cookie: portal
+    browser.cookies.set("portal", portal_toekn, domain=PORTAL_COOKIE_DOMAIN)
+    # 設定模擬瀏覽器的 User-Agent Header
+    browser.headers.update(
+        {"User-Agent": BROWSER_USER_AGENT, "Accept-Language": ACCEPT_LANGUAGE})
+
+    return browser

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,8 +1,12 @@
 import os
 from utils.cron import validate_cron_expression, validate_cron_jobs_scheduling_config
+from utils.token_verifier import verify_ncu_portal_token
 
 
 def validate_config():
+    # 檢查 PORTAL_TOKEN 登入狀態的有效性
+    verify_ncu_portal_token()
+
     # 從環境變數取得排程時間相關設定變數
     signing_day = os.environ.get("SIGNING_DAY")
     sign_in_hour = os.environ.get("SIGN_IN_HOUR")

--- a/utils/token_verifier.py
+++ b/utils/token_verifier.py
@@ -1,0 +1,27 @@
+import logging
+import os
+from lxml import etree
+from ncu_hsys.constants import NCU_PORTAL_URL, LOGIN_PAGE_XPATH
+from ncu_hsys.utils.browser import init_browser
+
+
+def verify_ncu_portal_token() -> None:
+    # 從環境變數取得 PORTAL_TOKEN
+    portal_token = os.environ.get("PORTAL_TOKEN")
+
+    # 初始化 Requests Session
+    browser = init_browser(portal_token)
+
+    # 進到 Portal 登入畫面
+    res = browser.get(NCU_PORTAL_URL.LOGIN)
+
+    # 解析回應
+    html = etree.HTML(res.text)
+
+    # 在頁面中尋找 Token 有效期限
+    # 若正確使用有效的 PORTAL_TOKEN 會在頁面上找到「記住我」登入剩餘有效時間
+    try:
+        remaing_day_msg = html.xpath(LOGIN_PAGE_XPATH.REMAING_DAY_MSG)[0]
+        logging.info(remaing_day_msg)
+    except IndexError:
+        raise Exception("PORTAL_TOKEN無效，請重新檢查其登入狀態有效性")


### PR DESCRIPTION
verify the login status of the portal token by finding the remaining day msg on the login page (the msg will exist if the token is validated).

- add a constant for the xpath of the remaining day msg
- change the default accept-language for the request page
- move out the init_browser func to the utils/browser.py
- add a verify_ncu_portal_token in validate_config func for verifying the portal token
- implement the verify_ncu_portal_token func